### PR TITLE
Fixed error (in some cases) in function getFileNameWithSize().

### DIFF
--- a/f-seo-agi.php
+++ b/f-seo-agi.php
@@ -302,14 +302,16 @@ function getFileNameWithSize($find_file_name, $path, $orientation, $width, $prop
 
         // если имя картинки совпало с искомым
 //        if ($s || $s === 0) {
-            $cut_height = str_replace($find_file_name . 'x', '', $name);
+            $cutHeight = (int)str_replace($find_file_name . 'x', '', $name);
 
             if (
-                ($orientation === 'horizontal' && (int)$width > (int)$cut_height)
-                || ($orientation === 'vertical' && (int)$width < (int)$cut_height)
-                || ($orientation === 'square' && (int)$width === (int)$cut_height)
+                $cutHeight && (
+                    ($orientation === 'horizontal' && (int)$width > $cutHeight)
+                    || ($orientation === 'vertical' && (int)$width < $cutHeight)
+                    || ($orientation === 'square' && (int)$width === $cutHeight)
+                )
             ) {
-                $ar[] = [$name, (int)$width / (int)$cut_height];
+                $ar[] = [$name, (int)$width / $cutHeight];
             } else {
                 continue;
             }


### PR DESCRIPTION
Example fixed error:

`[Mon Jul 27 10:42:04 2020] [warn] [pid 28558] sapi_apache2.c(351): [client xxx.xxx.xxx.xxx:xxxxx] PHP Warning:  Division by zero in /home/xxx/public_html/wp-content/plugins/f-seo-auto-google-images/f-seo-agi.php on line 312`